### PR TITLE
#159388456 Create delete diary endpoint with test suits

### DIFF
--- a/src/contollers/EntryController.js
+++ b/src/contollers/EntryController.js
@@ -26,10 +26,10 @@ export const findOneById = (req, res) => {
 
   db.one('SELECT * FROM entries WHERE id = $1 AND users_id = $2', [entryId, req.user.id])
     .then((entries) => res.status(200).json(entries))
-    .catch(() => res.status(404).send('No diary found with this ID'));
+    .catch(() => res.status(404).send('None of your diaries was found with this ID'));
 };
 
-// // UPDATE A SINGLE ENTRY IN MEMORY
+// // UPDATE A SINGLE ENTRY
 // export const updateOne = (req, res) => {
 //   Entry.findByIdAndUpdate(req.params.id,
 //     {
@@ -40,3 +40,13 @@ export const findOneById = (req, res) => {
 //     .then(entry => res.status(200).json(entry))
 //     .catch(() => res.status(500).send('There was a problem updating the entry.'));
 // };
+
+
+// DELETE A SINGLE ENTRY
+export const findByIdAndRemove = (req, res) => {
+  const entryId = parseInt(req.params.id);
+
+  db.result('DELETE FROM entries WHERE id = $1 AND users_id = $2', [entryId, req.user.id])
+    .then((entries) => res.status(200).send('Diary was deleted successfully!!!'))
+    .catch(() => res.status(500).send('There was a problem deleting the entry.'));
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,7 +3,7 @@ import { signUp, logIn } from '../contollers/UserController';
 import isAnyEmpty from '../middlewares/isAnyEmpty';
 import doesUserExist from '../middlewares/doesUserExist';
 import hashPassword from '../middlewares/hashPassword';
-import { findAll, findOneById } from '../contollers/EntryController';
+import { findAll, findOneById, findByIdAndRemove } from '../contollers/EntryController';
 import isEmail from '../middlewares/isEmail';
 import isAuth from '../middlewares/isAuth';
 
@@ -35,5 +35,8 @@ router.get('/entries/:id', isAuth, findOneById);
 
 // // UPDATE ONE ENTRY
 // router.put('/entries/:id', updateOne);
+
+// DELETE ONE ENTRY
+router.delete('/entries/:id', isAuth, findByIdAndRemove);
 
 export default router;

--- a/src/tests/entry.spec.js
+++ b/src/tests/entry.spec.js
@@ -46,6 +46,7 @@ describe('Entry', () => {
 
           expect(res).to.have.status(200);
           expect(res.body).to.be.an('array');
+          expect(res.body).to.have.lengthOf(0);
           done();
         });
     });
@@ -67,6 +68,40 @@ describe('Entry', () => {
         .then((entry) => {
           chai.request(app)
           .get(`${baseUrl}/entries/${entry.id}`)
+          .set('Authorization', `Bearer ${jwt}`)
+          .end((error, res) => {
+            if(error) done(error);
+
+            expect(res).to.have.status(200);
+            expect(res.body).to.have.property('title').to.equal('play of all');
+            expect(res.body).to.have.property('body').to.equal('He plays all time');
+            expect(res.body).to.have.property('feature_image').to.equal('http://image.jpg');
+            expect(res.body).to.have.property('id').eql(entry.id);
+            expect(res.body).to.have.property('users_id').eql(1);
+            done();
+          })
+          done();
+        })
+        .catch(() => done())
+    });
+  });
+
+  describe('DELETE /entries/:id', () => {
+
+    const newEntry = {
+      title: 'play of all',
+      body: 'He plays all time',
+      feature_image: 'http://image.jpg',
+      users_id: 1
+    };
+
+    it('should DELETE only ONE entry by id', (done) => {
+
+      db.one('INSERT INTO entries(title, body, feature_image, users_id)' +
+      'VALUES(${title}, ${body}, ${feature_image}, ${users_id}) returning *', newEntry)
+        .then((entry) => {
+          chai.request(app)
+          .delete(`${baseUrl}/entries/${entry.id}`)
           .set('Authorization', `Bearer ${jwt}`)
           .end((error, res) => {
             if(error) done(error);


### PR DESCRIPTION
#### What does this PR do?
Delete diary endpoint with a test suite cases

#### Description of Task to be completed?
- Create findByIdAndRemove controller that handle delete request
- Secure delete routes with jsonwebtoken
- Return 'diary was successfully deleted' when a diary is deleted.

#### How should this be manually tested?
After cloning the repo, cd into the directory. RUN 'npm install' to install dependencies.
RUN 'npm run dev' to start the app.
go to POSTMAN and enter the endpoint.
if you provide a correct token in the header and diary belong to a user, you will be able to delete the diary.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- Story type: feature
- Story title: User can delete entry endpoint with a test suite
- Story ID: #159388456

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A