### PR TITLE
#159746016 reorder middleware for proper validation

### DIFF
--- a/server/src/middlewares/functions.js
+++ b/server/src/middlewares/functions.js
@@ -133,32 +133,6 @@ export const isLoginEmpty = (req, res, next) => {
 };
 
 /**
-<<<<<<< HEAD
-=======
- * A function that check if the password and confirm password are the same.
- *
- * @param {Request: user input request} req
- * @param {Response: programs reponses} res
- * @param {Next: move on to the next middleware } next
- *
- * return boolean: true if valid move to the next middleware
- *  else
- * return status code 400 with 'Password do not match'
- */
-export const isPasswordEqual = (req, res, next) => {
-  const { password, confirmPassword } = req.body;
-
-  if (password === confirmPassword) {
-    return next();
-  }
-  return res.status(400).json({
-    status: 'error',
-    message: 'Password do not match'
-  });
-};
-
-/**
->>>>>>> 46db5dedc2f82fe86b76ab669f789797b27aa2e1
  * A function that check if user password is less than six character.
  *
  * @param {Request: user input request} req

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -37,10 +37,10 @@ router.get('/entries', isAuth, findAll);
 router.get('/entries/:id', isAuth, findOneById);
 
 // CREATE NEW ENTRY
-router.post('/entries', isDiaryContentEmpty, isDiaryLengthLess, isAuth, create);
+router.post('/entries', isAuth, isDiaryContentEmpty, isDiaryLengthLess, create);
 
 // UPDATE ONE ENTRY
-router.put('/entries/:id', isDiaryContentEmpty, isDiaryLengthLess, isAuth, findByIdAndUpdate);
+router.put('/entries/:id', isAuth, isDiaryContentEmpty, isDiaryLengthLess, findByIdAndUpdate);
 
 // DELETE ONE ENTRY
 router.delete('/entries/:id', isAuth, findByIdAndRemove);

--- a/server/src/tests/entry.spec.js
+++ b/server/src/tests/entry.spec.js
@@ -32,10 +32,10 @@ describe('Entries', () => {
       });
   });
 
-  after((done) => {
-    db.any('TRUNCATE  $1:name, $2:name CASCADE', ['users', 'entries'])
-      .then(() => done())
-      .catch(() => done());
+  after(() => {
+    db.none('TRUNCATE  $1:name, $2:name CASCADE', ['users', 'entries'])
+      .then(() => {})
+      .catch(() => {});
   });
 
   /* eslint-disable no-unused-expressions */

--- a/server/src/tests/user.spec.js
+++ b/server/src/tests/user.spec.js
@@ -26,10 +26,10 @@ describe('User', () => {
       });
   });
 
-  after((done) => {
-    db.any('TRUNCATE  $1:name, $2:name CASCADE', ['users', 'entries'])
-      .then(() => done())
-      .catch(() => done());
+  after(() => {
+    db.none('TRUNCATE  $1:name, $2:name CASCADE', ['users', 'entries'])
+      .then(() => {})
+      .catch(() => {});
   });
 
   /* eslint-disable no-unused-expressions */
@@ -239,7 +239,7 @@ describe('User', () => {
           .post(`${baseUrl}/users/login`)
           .send(loginUser)
           .end((error, res) => {
-            if (error) done();
+            if (error) done(error);
 
             expect(res).to.have.status(200);
             expect(res.body).to.be.header;


### PR DESCRIPTION
#### What does this PR do?
Reorder update and create diary entry endpoint routes

#### Description of Task to be completed?
Place isAuth middleware before isDiaryContentEmpty and isDiaryLengthLess middleware in the update and create diary endpoint routes.

#### How should this be manually tested?
After cloning the repo, cd into the directory. RUN 'npm install' to install dependencies.
RUN 'npm run dev' to start the app.
go to POSTMAN and enter the endpoint.
Authentication validation checks first before the length and empty input fields validation is checked

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- Story type: bug
- Story title: Proper placement of middleware
- Story ID: #159746016

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A