### PR TITLE
#159876101 user get only the diary they create

### DIFF
--- a/server/src/contollers/EntryController.js
+++ b/server/src/contollers/EntryController.js
@@ -17,12 +17,12 @@ export const create = (req, res) => {
   title.trim();
   body.trim();
 
-  const usersId = req.user.id;
+  const users_id = req.user.id;
 
   /* eslint-disable no-template-curly-in-string */
   db.one('INSERT INTO entries(title, body, users_id)'
   + 'VALUES(${title}, ${body}, ${users_id}) RETURNING *',
-  { title, body, users_id: usersId })
+  { title, body, users_id })
     .then(entry => res.status(201).json(entry))
     .catch(() => res.status(500).json({
       status: 'error',


### PR DESCRIPTION
#### What does this PR do?
Enable user to get only the diary they create

#### Description of Task to be completed?
-  a user gets only the diary they create

#### How should this be manually tested?
- visit `https://onwuvic.github.io/MyDiary/UI/#/login` and log in
- create a new diary
-you should see only the diary you have created.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- Story type: bug
- Story title: All users get the same diaries
- Story ID: #159876101

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A