### PR TITLE
#160017603 add delete functionality to the front-end UI

### DIFF
--- a/UI/app/components/delete.js
+++ b/UI/app/components/delete.js
@@ -1,0 +1,29 @@
+(function () {
+    app.addComponent({
+        name: 'delete',
+        model: {
+            loading: true
+        },
+        view,
+        controller
+    });
+  
+    function view() {
+        if(this.loading) return 'Deleting...';
+    }
+  
+    function controller() {
+        const id = router.params[0];
+        this.loading = true;
+    
+        api.getOneDiaryByIdAndDelete(id)
+            .then(data => {
+                this.loading = false;
+                if(data.status == 'error') {
+                    console.log(data.message)
+                } else {
+                    window.location.replace('#/diary');
+                }
+            });
+    }
+  })();

--- a/UI/app/lib/Api.js
+++ b/UI/app/lib/Api.js
@@ -97,6 +97,18 @@ class Api {
         .then((res) => res.json());
     }
 
+    getOneDiaryByIdAndDelete(id) {
+        return fetch(`${this.API_URL}/entries/${id}`, {
+            method: 'DELETE',
+            mode: 'cors',
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Authorization': `Bearer ${this.token}`,
+            }
+        })
+        .then((res) => res.json());
+    }
+
 
     
 }

--- a/UI/app/main.js
+++ b/UI/app/main.js
@@ -13,5 +13,6 @@ router.addRouter('diaries', '^/diary$');
 router.addRouter('diary', '^/diary/(.*)$');
 router.addRouter('newDiary', '^/new$');
 router.addRouter('edit', '^/edit/(.*)$');
+router.addRouter('delete', '^/delete/(.*)$');
 router.addRouter('notification', '^/notification$');
 router.addRouter('settings', '^/settings$');

--- a/UI/index.html
+++ b/UI/index.html
@@ -25,6 +25,7 @@
     <script src="app/components/diary.js"></script>
     <script src="app/components/newDiary.js"></script>
     <script src="app/components/edit.js"></script>
+    <script src="app/components/delete.js"></script>
     <script src="app/components/notification.js"></script>
     <script src="app/components/settings.js"></script>
 </body>


### PR DESCRIPTION
#### What does this PR do?
Enable user to delete their diary from the frontend

#### Description of Task to be completed?
- Create a delete route
- Create a delete controller to handle the delete functionality

#### How should this be manually tested?
- visit `https://onwuvic.github.io/MyDiary/UI/` and log in
- Create a new diary
- Hit the delete button/link to delete.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- Story type: feature
- Story title: User can delete diary entry from the frontend
- Story ID: #160017603

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A